### PR TITLE
Quick quiz improvement in animation and save highscore dialog

### DIFF
--- a/src/app/quick-quiz/components/quick-quiz-end-dialog/quick-quiz-end-dialog.component.ts
+++ b/src/app/quick-quiz/components/quick-quiz-end-dialog/quick-quiz-end-dialog.component.ts
@@ -41,7 +41,8 @@ export class QuickQuizEndDialogComponent implements OnInit {
       time: moment().utc().format('DD/MM/YYYY HH:mm'),
     };
 
-    this.quickQuizService.saveScore(payload);
-    this.dialogRef.close(true);
+    this.quickQuizService.saveScore(payload).finally(() => {
+      this.dialogRef.close(true);
+    });
   }
 }

--- a/src/app/quick-quiz/components/quick-quiz-highscore/quick-quiz-highscore.component.ts
+++ b/src/app/quick-quiz/components/quick-quiz-highscore/quick-quiz-highscore.component.ts
@@ -24,7 +24,7 @@ import { SubSink } from 'subsink';
           [
             style({ opacity: 0 }),
             stagger(
-              '800ms',
+              '600ms',
               animate(
                 '500ms cubic-bezier(.34,.02,.81,1)',
                 style({ opacity: 1 })
@@ -35,7 +35,7 @@ import { SubSink } from 'subsink';
         ),
         query(
           ':leave',
-          [stagger('500ms', animate('200ms', style({ opacity: 0 })))],
+          [stagger('0ms', animate('0ms', style({ opacity: 0 })))],
           {
             optional: true,
           }
@@ -56,8 +56,11 @@ export class QuickQuizHighscoreComponent implements OnInit, OnDestroy {
 
   getHighScore() {
     this.subs.sink = this.quickQuizService.getHighScore().subscribe((x) => {
+      this.highscore = [];
       if (x && x.length) {
-        this.highscore = x;
+        setTimeout(() => {
+          this.highscore = _.cloneDeep(x);
+        }, 1000);
       }
     });
   }

--- a/src/app/quick-quiz/quick-quiz.guard.ts
+++ b/src/app/quick-quiz/quick-quiz.guard.ts
@@ -17,19 +17,19 @@ export class QuickQuizGuard implements CanActivate {
   canActivate(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): true | any {
+  ): true | UrlTree {
     const sessionToken = this.quickQuizService.sessionToken;
     const token = sessionToken?.token;
     const quizOption = this.quickQuizService.getQuizSettings();
     return this.checkToken(token, quizOption);
   }
 
-  checkToken(token: any, quizOption: any): true | any {
+  checkToken(token: any, quizOption: any): true | UrlTree {
     if (token && quizOption) {
       return true;
     } else {
       console.log(`token: ${token}, option ${quizOption}`);
-      return this.router.navigate(['quick-quiz']);
+      return this.router.createUrlTree(['quick-quiz']);
     }
   }
 }

--- a/src/app/service/quick-quiz/quick-quiz.service.ts
+++ b/src/app/service/quick-quiz/quick-quiz.service.ts
@@ -1,6 +1,10 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/firestore';
+import {
+  AngularFirestore,
+  DocumentData,
+  DocumentReference,
+} from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Score } from 'src/app/shared/interface/quick-quiz/quick-quiz';
@@ -80,7 +84,7 @@ export class QuickQuizService {
       );
   }
 
-  saveScore(payload: any) {
-    this.quickQuizCollection.collection('highscore').add(payload);
+  saveScore(payload: any): Promise<DocumentReference<DocumentData>> {
+    return this.quickQuizCollection.collection('highscore').add(payload);
   }
 }


### PR DESCRIPTION
Quick quiz guard now return url tree instead direct navigation
Save score now return as promise so after the process complete it execute close dialog method
Improve animation of highscore list in quick quiz page